### PR TITLE
Add blog post on hiring

### DIFF
--- a/blog/_posts/2023-07-21-2023-nextstrain-hiring.md
+++ b/blog/_posts/2023-07-21-2023-nextstrain-hiring.md
@@ -4,16 +4,146 @@ title: Openings for bioinformatics analyst and software engineer to contribute t
 author: Trevor Bedford
 ---
 
-Positions for a [bioinformatics analyst](#bioinformatics-analyst) and a [software engineer](#software-engineer) are available immediately in the Bedford lab at the Fred Hutch. Details for both positions follow:
+Positions for a [bioinformatics analyst](#bioinformatics-analyst-iiiii) and a [software engineer](#software-engineer-ii) are available immediately in the Bedford lab at the Fred Hutch. Details for both positions follow:
 
 -----------------------------------------
 
-### bioinformatics analyst
+### Bioinformatics Analyst II/III
 
-**TODO**
+#### Overview
+
+Fred Hutchinson Cancer Center is an independent, nonprofit organization providing adult cancer treatment and groundbreaking research focused on cancer and infectious diseases. Based in Seattle, Fred Hutch is the only National Cancer Institute-designated cancer center in Washington.
+
+With a track record of global leadership in bone marrow transplantation, HIV/AIDS prevention, immunotherapy and COVID-19 vaccines, Fred Hutch has earned a reputation as one of the world's leading cancer, infectious disease and biomedical research centers. Fred Hutch operates eight clinical care sites that provide medical oncology, infusion, radiation, proton therapy and related services, and network affiliations with hospitals in five states. Together, our fully integrated research and clinical care teams seek to discover new cures to the world's deadliest diseases and make life beyond cancer a reality.
+
+At Fred Hutch we value collaboration, compassion, determination, excellence, innovation, integrity and respect. These values are grounded in and expressed through the principles of diversity, equity and inclusion. Our mission is directly tied to the humanity, dignity and inherent value of each employee, patient, community member and supporter. Our commitment to learning across our differences and similarities make us stronger. We seek employees who bring different and innovative ways of seeing the world and solving problems. Fred Hutch is in pursuit of becoming an anti-racist organization. We are committed to ensuring that all candidates hired share our commitment to diversity, anti-racism and inclusion.
+
+We have an opening for a bioinformatician in the [Bedford lab](https://bedford.io/) at the Fred Hutch to work on genomic epidemiology and evolutionary analysis of pathogens such as SARS-CoV-2, seasonal influenza, and [other emerging and endemic pathogens](https://nextstrain.org/pathogens). This position will contribute to ongoing work for the Bedford lab and Nextstrain.
+
+[Nextstrain](https://nextstrain.org/) is an award-winning project for tracking infectious disease epidemics developed in collaboration with the [Neher lab](https://neherlab.org/) at the University of Basel. Nextstrain won the [Open Science Prize](https://www.nih.gov/news-events/news-releases/open-science-prize-announces-epidemic-tracking-tool-grand-prize-winner) in Feb 2017 and has been instrumental in analysis of the [SARS-CoV-2 pandemic](https://nextstrain.org/sars-cov-2), [Ebola outbreaks](https://nextstrain.org/community/inrb-drc/ebola-nord-kivu), [Zika spread](https://nextstrain.org/zika/) in the Americas and is used by the World Health Organization to aid in the process of [influenza vaccine strain selection](https://nextstrain.org/flu/). The software we write to power [all parts](https://docs.nextstrain.org/en/latest/learn/parts.html) of Nextstrain---bioinformatics, visualizations, analysis pipelines, data management, and more---is entirely [open-source](https://opensource.org/osd) and [available to the public](https://github.com/nextstrain). We work with public health entities and scientists across the world, both formally and informally, to expand pathogen surveillance capabilities and to improve the automation and robustness of these analyses. Our goal is to empower the wider genomic epidemiology and public health communities to tweak our analyses, create new ones, and communicate scientific insights using the same tools we do.
+
+#### Responsibilities
+
+This role advances the research aims of the Bedford lab and the Nextstrain team through a combination of independent work, collaboration with scientists and software developers in the group, and interactions with the wider public health and science communities. In this role, the bioinformatician will:
+
+-   Develop and maintain analytic pipelines such as those that clean and ingest genome metadata, build phylogenetic trees, and run forecasting models for SARS-CoV-2 and other pathogens
+-   Improve the robustness, automation, and monitoring of our existing pathogen pipelines
+-   Develop reproducible pipelines to expand surveillance of endemic and emerging human pathogens, in collaboration with both internal and external groups
+-   Participate in community outreach through office hours, discussion forums, and mailing lists
+-   Write and maintain thorough documentation on software and pipelines
+-   Design software with a diverse range of collaborators and users in mind
+-   Contribute to the Nextstrain team's decision-making and planning processes
+-   Present at Bedford lab meetings
+
+#### Qualifications
+
+##### Minimum qualifications
+
+-   Master's degree in bioinformatics, computational biology, biology, or related field with at least three years' direct experience in computational analysis of large sequence-based molecular data sets.
+-   Fluency in at least one high-level programming language, such as Python, R, Ruby, JavaScript, or Perl
+-   Familiarity with version control and other software development best practices
+-   Experience with workflow managers such as Snakemake, Nextflow, or WDL
+-   Knowledge of molecular biology
+-   Motivated to learn new skills and technologies and collaborate within an existing team's practices
+-   Excellent written and verbal communication skills
+
+##### Preferred qualifications
+
+-   Expertise in genomics
+-   Knowledge of automated testing and workflows such as GitHub Actions
+-   Experience configuring and deploying analyses on a cloud infrastructure
+
+To aid in applicant review, a coding sample is requested. We're happy to review whatever you're most proud of (in any programming language). If you don't have code that can be publicly shared, that's okay. Please apply anyway and just let us know that this isn't available.
+
+If you think you might be a great fit for this position but are concerned about meeting all qualifications, we'd like to hear from you. Please email Trevor Bedford at tb@bedford.io or John Huddleston at jhuddles@fredhutch.org.
+
+Fred Hutchinson Cancer Center has a mandatory COVID-19 vaccine requirement, with exceptions only for approved medical or religious accommodations. As a condition of employment, newly hired employees must, prior to their first day of employment:\
+Provide proof of being fully vaccinated against COVID-19 ; OR\
+Initiate the accommodations process to request a religious or medical accommodation (medical accommodations require a healthcare provider's certification).
+
+*A [statement](https://fhcrc.icims.com/icims2/servlet/icims2?module=AppInert&action=download&id=398148&hashed=1756257730) describing your commitment and contributions toward greater diversity, equity, inclusion, and antiracism in your career or that will be made through your work at Fred Hutch is requested of all finalists.*
+
+---
+
+The annual base salary range for the level II position is from $74,358 to $111,536 and pay offered will be based on experience and qualifications.  
+
+The annual base salary range for the level III position is from $86,078 to $129,118 and pay offered will be based on experience and qualifications.  
+
+This position may be eligible for relocation assistance.
+
+Fred Hutchinson Cancer Center offers employees a [comprehensive benefits package](https://extranet.fredhutch.org/en/u/benefits.html) designed to enhance health, well-being, and financial security. Benefits include medical/vision, dental, flexible spending accounts, life, disability, retirement, family life support, employee assistance program, onsite health clinic, tuition reimbursement, paid vacation (12-22 days per year), paid sick leave (12-25 days per year), paid holidays (13 days per year), paid parental leave (up to 4 weeks), and partially paid sabbatical leave (up to 6 months).  
+
+#### Our Commitment to Diversity
+
+We are proud to be an Equal Employment Opportunity (EEO) and Vietnam Era Veterans Readjustment Assistance Act (VEVRAA) Employer. We are committed to cultivating a workplace in which diverse perspectives and experiences are welcomed and respected. We do not discriminate on the basis of race, color, religion, creed, ancestry, national origin, sex, age, disability (physical or mental), marital or veteran status, genetic information, sexual orientation, gender identity, political ideology, or membership in any other legally protected class. We are an Affirmative Action employer. We encourage individuals with diverse backgrounds to apply and desire priority referrals of protected veterans. If due to a disability you need assistance/and or a reasonable accommodation during the application or recruiting process, please send a request to our Employee Services Center at hrops@fredhutch.org or by calling 206-667-4700.
+
+Not ready to apply? [Connect with us](https://careers-fhcrc.icims.com/connect) for general consideration.
 
 -----------------------------------------
 
-### Software Engineer
+### Software Engineer II
 
-**TODO**
+The [Bedford Lab](https://bedford.io/) at the [Fred Hutch](https://fredhutch.org/) is seeking a software engineer to work on [Nextstrain](https://nextstrain.org/), an [award-winning](https://www.nih.gov/news-events/news-releases/open-science-prize-announces-epidemic-tracking-tool-grand-prize-winner) project for tracking infectious disease epidemics such as the [SARS-CoV-2 pandemic](https://nextstrain.org/sars-cov-2), [Ebola outbreaks](https://nextstrain.org/community/inrb-drc/ebola-nord-kivu), [Zika spread](https://nextstrain.org/zika/) in the Americas, [seasonal flu](https://nextstrain.org/flu/), and [other emerging and endemic pathogens](https://nextstrain.org/pathogens). This position will augment our existing team to design, develop, maintain, operate, and support our software and services that empower research scientists and public health practitioners in the lab and around the world.
+
+Nextstrain, developed in collaboration with the [Neher Lab](https://neherlab.org/) at the University of Basel, provides tools for evolutionary analysis of pathogens and genomic epidemiology. We write [open source software](https://github.com/nextstrain/) in a public development style to power [all parts](https://docs.nextstrain.org/en/latest/learn/parts.html) of Nextstrain---bioinformatics, visualizations, analysis pipelines, data management, and more---and our analyses use open data whenever possible. We work with public health entities and scientists across the world, both formally and informally, to expand pathogen surveillance capabilities and to improve the automation and robustness of these analyses. Our goal is to empower the wider genomic epidemiology and public health communities to tweak our analyses, create new ones, and communicate scientific insights using the same tools we do.
+
+#### About the role:
+
+This position will be responsible for general software engineering and development work across the entire Nextstrain stack. This includes command-line applications for bioinformatics and data/workflow management (e.g. [Augur](https://github.com/nextstrain/augur), [Nextstrain CLI](https://github.com/nextstrain/cli)), visualization applications for phylogenetics (e.g. [Auspice](https://github.com/nextstrain/auspice)), full-stack web applications for sharing analyses (e.g. [nextstrain.org](https://github.com/nextstrain/nextstrain.org)), workflows for data curation and analysis (e.g. [ncov-ingest](https://github.com/nextstrain/ncov-ingest/)), runtimes for Nextstrain analyses (e.g. [docker-base](https://github.com/nextstrain/docker-base), [conda-base](https://github.com/nextstrain/conda-base)), and internal tooling/infrastructure to support all of that.
+
+Application instructions: To aid in applicant review, we request you submit a cover letter, your resume, and a coding sample. For the coding sample, we're happy to review whatever you're most proud of (in any programming language). If you don't have code that can be publicly shared, that's okay. Please apply anyway and just let us know that this isn't available. If you're interested in this position but are concerned about meeting all the qualifications, we'd like to hear from you. Please email Trevor Bedford at <tb@bedford.io> and Thomas Sibley at <tsibley@fredhutch.org>.
+
+#### What we provide:
+
+- Empowerment to craft software that helps protect the world from epidemics and pandemics
+- Thrive in an ecosystem of cross-disciplinary learning, drawing insights from scientists, public health practitioners, and fellow software developers
+- A team that believes in continuous learning and cultivates an environment where all members of the group help each other
+- Opportunity for growth as a software developer in areas of personal interest (e.g. front-end JavaScript, back-end infrastructure, data pipelines, being a project lead, etc.)
+- A team culture that champions a healthy work life balance
+- A competitive compensation package, with comprehensive health and welfare benefits
+
+#### What you'll do:
+
+- Design, develop, test, document, and maintain software under a coherent ecosystem
+- Release new versions of packaged programs for installation by users and deploy new versions of hosted services to users
+- Configure and manage cloud infrastructure resources (e.g. AWS, Heroku, Terraform)
+- Create, extend, and troubleshoot automated workflows (e.g. GitHub Actions, Snakemake, Nextflow, WDL)
+- Participate in constructive code review processes with other team members
+- Support internal and external users of software projects via various communication channels
+
+Integrating with an existing team both in-person and online is a key aspect of this position. This position will work daily within a small team of Bedford Lab members and collaborators. The Nextstrain team communicates openly about project and organizational decisions and encourages participation by all team members in decision-making.
+
+#### What you bring:
+
+- 3+ years of experience in software engineering
+- Fluency in Python and JavaScript/TypeScript, or fluency in similar languages
+- Proficiency with Linux/Unix and command-line interfaces
+- Proficiency with version control and software development best practices
+- Excellent written and verbal communication skills
+- Motivation to learn and collaborate within an existing team's practices
+
+#### Physical Requirements:
+
+Remaining in a normal seated or standing position for extended periods of time; reaching and grasping by extending hand(s) or arm(s); dexterity to manipulate objects with fingers, for example using a keyboard; communication skills using the spoken word; ability to see and hear within normal parameters; ability to move about workspace. The position requires mobility, including the ability to move materials weighing up to several pounds (such as a laptop computer or tablet).
+
+Persons with disabilities may be able to perform the essential duties of this position with reasonable accommodation. Requests for reasonable accommodation will be evaluated on an individual basis.
+
+#### Please Note:
+
+This job description sets forth the job's principal duties, responsibilities, and requirements; it should not be construed as an exhaustive statement, however. Unless they begin with the word "may," the Essential Duties and Responsibilities described above are "essential functions" of the job, as defined by the Americans with Disabilities Act.
+
+#### Compensation and Benefits
+
+Our employees are compensated from a total rewards perspective in many ways for their contributions to our mission, including competitive pay, exceptional health benefits, retirement plans, time off, and a range of recognition and wellness programs. Visit our [Benefits at HHMI](https://www.hhmi.org/careers/benefits-at-a-glance) site to learn more. 
+
+*Compensation Range*
+
+$89,585.00 (minimum) - $112,000.00 (midpoint) - $145,590.00 (maximum)
+
+Pay Type:
+
+Annual
+
+HHMI's salary structure is developed based on relevant job market data. HHMI considers a candidate's education, previous experiences, knowledge, skills and abilities, as well as internal equity when making job offers. Typically, a new hire for this position in this location is compensated between the minimum and the midpoint of the salary range.
+
+[HHMI is an Equal Opportunity Employer](https://www.hhmi.org/careers/equal-opportunity)

--- a/blog/_posts/2023-07-21-2023-nextstrain-hiring.md
+++ b/blog/_posts/2023-07-21-2023-nextstrain-hiring.md
@@ -49,6 +49,8 @@ To aid in applicant review, a coding sample is requested. We're happy to review 
 
 If you think you might be a great fit for this position but are concerned about meeting all qualifications, we'd like to hear from you. Please email Trevor Bedford at tb@bedford.io or John Huddleston at jhuddles@fredhutch.org.
 
+To apply for this position, please go to the [official Fred Hutch listing](https://careers-fhcrc.icims.com/jobs/25697/job).
+
 -----------------------------------------
 
 ### Software Engineer II
@@ -91,3 +93,5 @@ Integrating with an existing team both in-person and online is a key aspect of t
 - Proficiency with version control and software development best practices
 - Excellent written and verbal communication skills
 - Motivation to learn and collaborate within an existing team's practices
+
+To apply for this position, please go to the [official HHMI listing](https://hhmi.wd1.myworkdayjobs.com/en-US/External/job/Software-Engineer-II--Bedford-Lab_R-2176).

--- a/blog/_posts/2023-07-21-2023-nextstrain-hiring.md
+++ b/blog/_posts/2023-07-21-2023-nextstrain-hiring.md
@@ -1,0 +1,19 @@
+---
+layout: post
+title: Openings for bioinformatics analyst and software engineer to contribute to Nextstrain platform
+author: Trevor Bedford
+---
+
+Positions for a [bioinformatics analyst](#bioinformatics-analyst) and a [software engineer](#software-engineer) are available immediately in the Bedford lab at the Fred Hutch. Details for both positions follow:
+
+-----------------------------------------
+
+### bioinformatics analyst
+
+**TODO**
+
+-----------------------------------------
+
+### Software Engineer
+
+**TODO**

--- a/blog/_posts/2023-07-21-2023-nextstrain-hiring.md
+++ b/blog/_posts/2023-07-21-2023-nextstrain-hiring.md
@@ -10,14 +10,6 @@ Positions for a [bioinformatics analyst](#bioinformatics-analyst-iiiii) and a [s
 
 ### Bioinformatics Analyst II/III
 
-#### Overview
-
-Fred Hutchinson Cancer Center is an independent, nonprofit organization providing adult cancer treatment and groundbreaking research focused on cancer and infectious diseases. Based in Seattle, Fred Hutch is the only National Cancer Institute-designated cancer center in Washington.
-
-With a track record of global leadership in bone marrow transplantation, HIV/AIDS prevention, immunotherapy and COVID-19 vaccines, Fred Hutch has earned a reputation as one of the world's leading cancer, infectious disease and biomedical research centers. Fred Hutch operates eight clinical care sites that provide medical oncology, infusion, radiation, proton therapy and related services, and network affiliations with hospitals in five states. Together, our fully integrated research and clinical care teams seek to discover new cures to the world's deadliest diseases and make life beyond cancer a reality.
-
-At Fred Hutch we value collaboration, compassion, determination, excellence, innovation, integrity and respect. These values are grounded in and expressed through the principles of diversity, equity and inclusion. Our mission is directly tied to the humanity, dignity and inherent value of each employee, patient, community member and supporter. Our commitment to learning across our differences and similarities make us stronger. We seek employees who bring different and innovative ways of seeing the world and solving problems. Fred Hutch is in pursuit of becoming an anti-racist organization. We are committed to ensuring that all candidates hired share our commitment to diversity, anti-racism and inclusion.
-
 We have an opening for a bioinformatician in the [Bedford lab](https://bedford.io/) at the Fred Hutch to work on genomic epidemiology and evolutionary analysis of pathogens such as SARS-CoV-2, seasonal influenza, and [other emerging and endemic pathogens](https://nextstrain.org/pathogens). This position will contribute to ongoing work for the Bedford lab and Nextstrain.
 
 [Nextstrain](https://nextstrain.org/) is an award-winning project for tracking infectious disease epidemics developed in collaboration with the [Neher lab](https://neherlab.org/) at the University of Basel. Nextstrain won the [Open Science Prize](https://www.nih.gov/news-events/news-releases/open-science-prize-announces-epidemic-tracking-tool-grand-prize-winner) in Feb 2017 and has been instrumental in analysis of the [SARS-CoV-2 pandemic](https://nextstrain.org/sars-cov-2), [Ebola outbreaks](https://nextstrain.org/community/inrb-drc/ebola-nord-kivu), [Zika spread](https://nextstrain.org/zika/) in the Americas and is used by the World Health Organization to aid in the process of [influenza vaccine strain selection](https://nextstrain.org/flu/). The software we write to power [all parts](https://docs.nextstrain.org/en/latest/learn/parts.html) of Nextstrain---bioinformatics, visualizations, analysis pipelines, data management, and more---is entirely [open-source](https://opensource.org/osd) and [available to the public](https://github.com/nextstrain). We work with public health entities and scientists across the world, both formally and informally, to expand pathogen surveillance capabilities and to improve the automation and robustness of these analyses. Our goal is to empower the wider genomic epidemiology and public health communities to tweak our analyses, create new ones, and communicate scientific insights using the same tools we do.
@@ -56,28 +48,6 @@ This role advances the research aims of the Bedford lab and the Nextstrain team 
 To aid in applicant review, a coding sample is requested. We're happy to review whatever you're most proud of (in any programming language). If you don't have code that can be publicly shared, that's okay. Please apply anyway and just let us know that this isn't available.
 
 If you think you might be a great fit for this position but are concerned about meeting all qualifications, we'd like to hear from you. Please email Trevor Bedford at tb@bedford.io or John Huddleston at jhuddles@fredhutch.org.
-
-Fred Hutchinson Cancer Center has a mandatory COVID-19 vaccine requirement, with exceptions only for approved medical or religious accommodations. As a condition of employment, newly hired employees must, prior to their first day of employment:\
-Provide proof of being fully vaccinated against COVID-19 ; OR\
-Initiate the accommodations process to request a religious or medical accommodation (medical accommodations require a healthcare provider's certification).
-
-*A [statement](https://fhcrc.icims.com/icims2/servlet/icims2?module=AppInert&action=download&id=398148&hashed=1756257730) describing your commitment and contributions toward greater diversity, equity, inclusion, and antiracism in your career or that will be made through your work at Fred Hutch is requested of all finalists.*
-
----
-
-The annual base salary range for the level II position is from $74,358 to $111,536 and pay offered will be based on experience and qualifications.  
-
-The annual base salary range for the level III position is from $86,078 to $129,118 and pay offered will be based on experience and qualifications.  
-
-This position may be eligible for relocation assistance.
-
-Fred Hutchinson Cancer Center offers employees a [comprehensive benefits package](https://extranet.fredhutch.org/en/u/benefits.html) designed to enhance health, well-being, and financial security. Benefits include medical/vision, dental, flexible spending accounts, life, disability, retirement, family life support, employee assistance program, onsite health clinic, tuition reimbursement, paid vacation (12-22 days per year), paid sick leave (12-25 days per year), paid holidays (13 days per year), paid parental leave (up to 4 weeks), and partially paid sabbatical leave (up to 6 months).  
-
-#### Our Commitment to Diversity
-
-We are proud to be an Equal Employment Opportunity (EEO) and Vietnam Era Veterans Readjustment Assistance Act (VEVRAA) Employer. We are committed to cultivating a workplace in which diverse perspectives and experiences are welcomed and respected. We do not discriminate on the basis of race, color, religion, creed, ancestry, national origin, sex, age, disability (physical or mental), marital or veteran status, genetic information, sexual orientation, gender identity, political ideology, or membership in any other legally protected class. We are an Affirmative Action employer. We encourage individuals with diverse backgrounds to apply and desire priority referrals of protected veterans. If due to a disability you need assistance/and or a reasonable accommodation during the application or recruiting process, please send a request to our Employee Services Center at hrops@fredhutch.org or by calling 206-667-4700.
-
-Not ready to apply? [Connect with us](https://careers-fhcrc.icims.com/connect) for general consideration.
 
 -----------------------------------------
 
@@ -121,29 +91,3 @@ Integrating with an existing team both in-person and online is a key aspect of t
 - Proficiency with version control and software development best practices
 - Excellent written and verbal communication skills
 - Motivation to learn and collaborate within an existing team's practices
-
-#### Physical Requirements:
-
-Remaining in a normal seated or standing position for extended periods of time; reaching and grasping by extending hand(s) or arm(s); dexterity to manipulate objects with fingers, for example using a keyboard; communication skills using the spoken word; ability to see and hear within normal parameters; ability to move about workspace. The position requires mobility, including the ability to move materials weighing up to several pounds (such as a laptop computer or tablet).
-
-Persons with disabilities may be able to perform the essential duties of this position with reasonable accommodation. Requests for reasonable accommodation will be evaluated on an individual basis.
-
-#### Please Note:
-
-This job description sets forth the job's principal duties, responsibilities, and requirements; it should not be construed as an exhaustive statement, however. Unless they begin with the word "may," the Essential Duties and Responsibilities described above are "essential functions" of the job, as defined by the Americans with Disabilities Act.
-
-#### Compensation and Benefits
-
-Our employees are compensated from a total rewards perspective in many ways for their contributions to our mission, including competitive pay, exceptional health benefits, retirement plans, time off, and a range of recognition and wellness programs. Visit our [Benefits at HHMI](https://www.hhmi.org/careers/benefits-at-a-glance) site to learn more. 
-
-*Compensation Range*
-
-$89,585.00 (minimum) - $112,000.00 (midpoint) - $145,590.00 (maximum)
-
-Pay Type:
-
-Annual
-
-HHMI's salary structure is developed based on relevant job market data. HHMI considers a candidate's education, previous experiences, knowledge, skills and abilities, as well as internal equity when making job offers. Typically, a new hire for this position in this location is compensated between the minimum and the midpoint of the salary range.
-
-[HHMI is an Equal Opportunity Employer](https://www.hhmi.org/careers/equal-opportunity)

--- a/blog/_posts/2023-07-21-2023-nextstrain-hiring.md
+++ b/blog/_posts/2023-07-21-2023-nextstrain-hiring.md
@@ -59,13 +59,11 @@ The [Bedford Lab](https://bedford.io/) at the [Fred Hutch](https://fredhutch.org
 
 Nextstrain, developed in collaboration with the [Neher Lab](https://neherlab.org/) at the University of Basel, provides tools for evolutionary analysis of pathogens and genomic epidemiology. We write [open source software](https://github.com/nextstrain/) in a public development style to power [all parts](https://docs.nextstrain.org/en/latest/learn/parts.html) of Nextstrain---bioinformatics, visualizations, analysis pipelines, data management, and more---and our analyses use open data whenever possible. We work with public health entities and scientists across the world, both formally and informally, to expand pathogen surveillance capabilities and to improve the automation and robustness of these analyses. Our goal is to empower the wider genomic epidemiology and public health communities to tweak our analyses, create new ones, and communicate scientific insights using the same tools we do.
 
-#### About the role:
+#### About the role
 
 This position will be responsible for general software engineering and development work across the entire Nextstrain stack. This includes command-line applications for bioinformatics and data/workflow management (e.g. [Augur](https://github.com/nextstrain/augur), [Nextstrain CLI](https://github.com/nextstrain/cli)), visualization applications for phylogenetics (e.g. [Auspice](https://github.com/nextstrain/auspice)), full-stack web applications for sharing analyses (e.g. [nextstrain.org](https://github.com/nextstrain/nextstrain.org)), workflows for data curation and analysis (e.g. [ncov-ingest](https://github.com/nextstrain/ncov-ingest/)), runtimes for Nextstrain analyses (e.g. [docker-base](https://github.com/nextstrain/docker-base), [conda-base](https://github.com/nextstrain/conda-base)), and internal tooling/infrastructure to support all of that.
 
-Application instructions: To aid in applicant review, we request you submit a cover letter, your resume, and a coding sample. For the coding sample, we're happy to review whatever you're most proud of (in any programming language). If you don't have code that can be publicly shared, that's okay. Please apply anyway and just let us know that this isn't available. If you're interested in this position but are concerned about meeting all the qualifications, we'd like to hear from you. Please email Trevor Bedford at <tb@bedford.io> and Thomas Sibley at <tsibley@fredhutch.org>.
-
-#### What we provide:
+#### What we provide
 
 - Empowerment to craft software that helps protect the world from epidemics and pandemics
 - Thrive in an ecosystem of cross-disciplinary learning, drawing insights from scientists, public health practitioners, and fellow software developers
@@ -74,7 +72,7 @@ Application instructions: To aid in applicant review, we request you submit a co
 - A team culture that champions a healthy work life balance
 - A competitive compensation package, with comprehensive health and welfare benefits
 
-#### What you'll do:
+#### What you'll do
 
 - Design, develop, test, document, and maintain software under a coherent ecosystem
 - Release new versions of packaged programs for installation by users and deploy new versions of hosted services to users
@@ -85,7 +83,7 @@ Application instructions: To aid in applicant review, we request you submit a co
 
 Integrating with an existing team both in-person and online is a key aspect of this position. This position will work daily within a small team of Bedford Lab members and collaborators. The Nextstrain team communicates openly about project and organizational decisions and encourages participation by all team members in decision-making.
 
-#### What you bring:
+#### Minimum qualifications
 
 - 3+ years of experience in software engineering
 - Fluency in Python and JavaScript/TypeScript, or fluency in similar languages
@@ -93,5 +91,9 @@ Integrating with an existing team both in-person and online is a key aspect of t
 - Proficiency with version control and software development best practices
 - Excellent written and verbal communication skills
 - Motivation to learn and collaborate within an existing team's practices
+
+To aid in applicant review, we request you submit a cover letter, your resume, and a coding sample. For the coding sample, we're happy to review whatever you're most proud of (in any programming language). If you don't have code that can be publicly shared, that's okay. Please apply anyway and just let us know that this isn't available.
+
+If you're interested in this position but are concerned about meeting all the qualifications, we'd like to hear from you. Please email Trevor Bedford at <tb@bedford.io> and Thomas Sibley at <tsibley@fredhutch.org>.
 
 To apply for this position, please go to the [official HHMI listing](https://hhmi.wd1.myworkdayjobs.com/en-US/External/job/Software-Engineer-II--Bedford-Lab_R-2176).


### PR DESCRIPTION
I can't figure out an easy way to preview how it would look on the live site, but you can look at the [Markdown preview](https://github.com/blab/blotter/blob/2023-nextstrain-hiring/blog/_posts/2023-07-21-2023-nextstrain-hiring.md).

URL will be `https://bedford.io/blog/2023-nextstrain-hiring/`.