### PR TITLE
ignore .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ projects/
 
 # Other files
 .DS_Store
+.ruby-version
 .tweet-cache


### PR DESCRIPTION
This file is used by rbenv to track which Ruby version is being used; adding it to .gitignore so my local checkout doesn't look like it's dirty. (I'm guessing most folks are just using their system Ruby version?)