### PR TITLE
Remove references to jobs we've hired for

### DIFF
--- a/misc/_posts/2013-10-27-join.md
+++ b/misc/_posts/2013-10-27-join.md
@@ -3,7 +3,7 @@ layout: misc
 title: Join
 ---
 
-*We are currently prioritizing a [bioinformatician to develop Nextstrain workflows](https://bedford.io/blog/2023-nextstrain-hiring/#bioinformatics-analyst-iiiii) and a [software engineer to do full-stack Nextstrain development](https://bedford.io/blog/2023-nextstrain-hiring/#software-engineer-ii). We are also particularly interested in postdoc candidates whose expertise includes genomic epidemiology, pathogen evolution or machine learning.*
+*We are particularly interested in postdoc candidates whose expertise includes genomic epidemiology, pathogen evolution or machine learning.*
 
 We are hiring across scientific and staff positions.  We place particular emphasis on evolution, epidemiology, virology and immunology, and especially their intersection. Lab members have spanned biologists, statisticians, physicists and computer scientists, high school students through postdocs. We are committed to improving diversity in the computational sciences. Applicants of diverse backgrounds are particularly encouraged to apply.
 


### PR DESCRIPTION
Removes references to bioinformatician and software engineer positions that we've hired for.